### PR TITLE
Requests notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ This epics adds a new role: approver. Approvers can approve and reject requests,
 - [X] As an admin I can see the requests link as well<br>
 - [X] As an employee I cannot see the requests link<br>
 - [ ] As an approver or admin, I can see a notification icon next to the request link that shows the number of pending requests<br>
-- [ ] As an approver, I can approve and reject requests<br>
+- [X] As an approver, I can approve and reject requests<br>
 - [X] As an approver, I do not have access to other admin functions (general, department, LDAP configuration, emails audit)<br>
 
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ This epics adds a new role: approver. Approvers can approve and reject requests,
 - [X] As an approver I can see a menu item in the top navbar next to calendar called "Requests" which links to "/requests"<br>
 - [X] As an admin I can see the requests link as well<br>
 - [X] As an employee I cannot see the requests link<br>
-- [ ] As an approver or admin, I can see a notification icon next to the request link that shows the number of pending requests<br>
+- [X] As an approver or admin, I can see a notification icon next to the request link that shows the number of pending requests<br>
 - [X] As an approver, I can approve and reject requests<br>
 - [X] As an approver, I do not have access to other admin functions (general, department, LDAP configuration, emails audit)<br>
 

--- a/app.js
+++ b/app.js
@@ -57,6 +57,12 @@ app.use(passport.session());
 //
 // Make sure session and user objects are available in templates
 app.use(function(req,res,next){
+    if(req.user) {
+      req.user.get_count_of_leaves()
+        .then( leaf => {
+          res.locals.requestCount = leaf.length
+        })
+    }
     res.locals.session     = req.session;
     res.locals.logged_user = req.user;
     res.locals.url_to_the_site_root = '/';

--- a/lib/model/mixin/user/absence_aware.js
+++ b/lib/model/mixin/user/absence_aware.js
@@ -311,15 +311,15 @@ module.exports = function(sequelize){
           return Promise.all(promiseArray)
             .then( userNames => {
               leaveInstance.forEach( (singleLeave, iterator) => {
-                console.log('SINGLELEAVE.DEDUCTION()', singleLeave.get_deducted_days_number())
                 containerOfLeaves.push({
-                  'created_at':singleLeave.dataValues.createdAt,
-                  'start_date':singleLeave.get_start_leave_day().date,
-                  'leave_date':singleLeave.get_end_leave_day().date,
+                  'created_at': singleLeave.dataValues.createdAt,
+                  'start_date': singleLeave.get_start_leave_day().date,
+                  'leave_date': singleLeave.get_end_leave_day().date,
                   'user': { 'department': { 'name': singleLeave.user.department.dataValues.name } },
-                  'full_name':userNames[iterator].dataValues.name+' '+userNames[iterator].dataValues.lastname,
-                  'leaveObject':singleLeave,
-                  'days':singleLeave.get_deducted_days_number()
+                  'full_name': userNames[iterator].dataValues.name+' '+userNames[iterator].dataValues.lastname,
+                  'leaveObject': singleLeave,
+                  'days': singleLeave.get_deducted_days_number(),
+                  'id': parseInt(singleLeave.id)
                 })
               })
               return containerOfLeaves

--- a/lib/model/mixin/user/absence_aware.js
+++ b/lib/model/mixin/user/absence_aware.js
@@ -310,7 +310,19 @@ module.exports = function(sequelize){
         if(promiseArray.length === leaveInstance.length) {
           return Promise.all(promiseArray)
             .then( userNames => {
-              return userNames
+              leaveInstance.forEach( (singleLeave, iterator) => {
+                console.log('SINGLELEAVE.DEDUCTION()', singleLeave.get_deducted_days_number())
+                containerOfLeaves.push({
+                  'created_at':singleLeave.dataValues.createdAt,
+                  'start_date':singleLeave.get_start_leave_day().date,
+                  'leave_date':singleLeave.get_end_leave_day().date,
+                  'user': { 'department': { 'name': singleLeave.user.department.dataValues.name } },
+                  'full_name':userNames[iterator].dataValues.name+' '+userNames[iterator].dataValues.lastname,
+                  'leaveObject':singleLeave,
+                  'days':singleLeave.get_deducted_days_number()
+                })
+              })
+              return containerOfLeaves
             })
         }
       })

--- a/lib/model/mixin/user/absence_aware.js
+++ b/lib/model/mixin/user/absence_aware.js
@@ -262,10 +262,23 @@ module.exports = function(sequelize){
   };
 
 
+  // Returns count of leaves that exist for anyone and everyone
+  this.get_count_of_leaves = function(){
+    return sequelize.models.Leave.findAll({
+      where : {
+        status : [
+          sequelize.models.Leave.status_new(),
+          sequelize.models.Leave.status_pended_revoke()
+        ]
+      }
+    })
+  }
+
   // Promise leaves that are needed to be Approved/Rejected
   //
   this.promise_leaves_to_be_processed = function(){
     var promiseArray = []
+    var containerOfLeaves = []
     return sequelize.models.Leave.findAll({
       include : [{
         model : sequelize.models.LeaveType,
@@ -293,8 +306,6 @@ module.exports = function(sequelize){
       }
     })
       .then( leaveInstance => {
-        // console.log('LEAVEINSTANCE', leaveInstance, '<=============')
-        // console.log('leaveType!!!', leaveInstance[0].dataValues.leave_type.dataValues.name, '<=============')
         let index = 0
         while(promiseArray.length < leaveInstance.length) {
           promiseArray.push(

--- a/lib/model/mixin/user/absence_aware.js
+++ b/lib/model/mixin/user/absence_aware.js
@@ -265,12 +265,8 @@ module.exports = function(sequelize){
   // Promise leaves that are needed to be Approved/Rejected
   //
   this.promise_leaves_to_be_processed = function(){
-<<<<<<< HEAD
-    return this.getSupervised_leaves({
-=======
     var promiseArray = []
     return sequelize.models.Leave.findAll({
->>>>>>> Adds custom query to get ALL leaves
       include : [{
         model : sequelize.models.LeaveType,
         as    : 'leave_type',
@@ -294,11 +290,6 @@ module.exports = function(sequelize){
           sequelize.models.Leave.status_new(),
           sequelize.models.Leave.status_pended_revoke()
         ]
-<<<<<<< HEAD
-      },
-    });
-  }; // END of promise_leaves_to_be_processed
-=======
       }
     })
       .then( leaveInstance => {
@@ -324,37 +315,6 @@ module.exports = function(sequelize){
         }
       })
   }
-
-
-  //   return this.getSupervised_leaves({
-  //     include : [{
-  //       model : sequelize.models.LeaveType,
-  //       as    : 'leave_type',
-  //     },{
-  //       model : sequelize.models.User,
-  //       as    : 'user',
-  //       include : [{
-  //         model : sequelize.models.Company,
-  //         as : 'company',
-  //         include : [{
-  //           model : sequelize.models.BankHoliday,
-  //           as    : 'bank_holidays',
-  //         }],
-  //       },{
-  //         model : sequelize.models.Department,
-  //         as    : 'department',
-  //       }],
-  //     }],
-  //     where : {
-  //       status : [
-  //         sequelize.models.Leave.status_new(),
-  //         sequelize.models.Leave.status_pended_revoke()
-  //       ]
-  //     },
-  //   });
-  // }; // END of promise_leaves_to_be_processed
->>>>>>> Adds custom query to get ALL leaves
-
 
   this.calculate_number_of_days_taken_from_allowence = function(args){
     var leave_type = args ? args.leave_type : null,
@@ -596,4 +556,3 @@ module.exports = function(sequelize){
   };
 
 };
-

--- a/lib/model/mixin/user/absence_aware.js
+++ b/lib/model/mixin/user/absence_aware.js
@@ -265,7 +265,12 @@ module.exports = function(sequelize){
   // Promise leaves that are needed to be Approved/Rejected
   //
   this.promise_leaves_to_be_processed = function(){
+<<<<<<< HEAD
     return this.getSupervised_leaves({
+=======
+    var promiseArray = []
+    return sequelize.models.Leave.findAll({
+>>>>>>> Adds custom query to get ALL leaves
       include : [{
         model : sequelize.models.LeaveType,
         as    : 'leave_type',
@@ -289,9 +294,66 @@ module.exports = function(sequelize){
           sequelize.models.Leave.status_new(),
           sequelize.models.Leave.status_pended_revoke()
         ]
+<<<<<<< HEAD
       },
     });
   }; // END of promise_leaves_to_be_processed
+=======
+      }
+    })
+      .then( leaveInstance => {
+        // console.log('LEAVEINSTANCE', leaveInstance, '<=============')
+        // console.log('leaveType!!!', leaveInstance[0].dataValues.leave_type.dataValues.name, '<=============')
+        let index = 0
+        while(promiseArray.length < leaveInstance.length) {
+          promiseArray.push(
+            sequelize.models.User.findOne({
+              attributes: ['name'],
+              where: {
+                id: leaveInstance[index].dataValues.userId
+              }
+            })
+          )
+          index++
+        }
+        if(promiseArray.length === leaveInstance.length) {
+          return Promise.all(promiseArray)
+            .then( userNames => {
+              return userNames
+            })
+        }
+      })
+  }
+
+
+  //   return this.getSupervised_leaves({
+  //     include : [{
+  //       model : sequelize.models.LeaveType,
+  //       as    : 'leave_type',
+  //     },{
+  //       model : sequelize.models.User,
+  //       as    : 'user',
+  //       include : [{
+  //         model : sequelize.models.Company,
+  //         as : 'company',
+  //         include : [{
+  //           model : sequelize.models.BankHoliday,
+  //           as    : 'bank_holidays',
+  //         }],
+  //       },{
+  //         model : sequelize.models.Department,
+  //         as    : 'department',
+  //       }],
+  //     }],
+  //     where : {
+  //       status : [
+  //         sequelize.models.Leave.status_new(),
+  //         sequelize.models.Leave.status_pended_revoke()
+  //       ]
+  //     },
+  //   });
+  // }; // END of promise_leaves_to_be_processed
+>>>>>>> Adds custom query to get ALL leaves
 
 
   this.calculate_number_of_days_taken_from_allowence = function(args){

--- a/lib/route/requests.js
+++ b/lib/route/requests.js
@@ -10,17 +10,16 @@ var express   = require('express'),
     EmailTransport  = require('../email');
 
 router.get('/', function(req, res){
-
-    Promise.join(
-        req.user.promise_my_active_leaves_ever(),
-        req.user.promise_leaves_to_be_processed(),
-        function(my_leaves, to_be_approved_leaves){
-            res.render('requests',{
-                my_leaves             : my_leaves,
-                to_be_approved_leaves : to_be_approved_leaves,
-            });
-        }
-    );
+  Promise.join(
+    req.user.promise_my_active_leaves_ever(),
+    req.user.promise_leaves_to_be_processed(),
+    function(my_leaves, to_be_approved_leaves){
+      res.render('requests',{
+          my_leaves             : my_leaves,
+          to_be_approved_leaves : to_be_approved_leaves,
+      });
+    }
+  );
 });
 
 function leave_request_action(args) {

--- a/lib/route/requests.js
+++ b/lib/route/requests.js
@@ -43,7 +43,14 @@ function leave_request_action(args) {
     }
 
     Promise.try(function(){
-      return req.user.promise_leaves_to_be_processed();
+      let leaveObjects = []
+      return req.user.promise_leaves_to_be_processed()
+        .then( leaves => {
+          leaves.forEach( leave => {
+            leaveObjects.push(leave.leaveObject)
+          })
+          return leaveObjects
+        })
     })
     .then(function(leaves){
        var leave_to_process = _.find(leaves, function(leave){

--- a/public/css/style.css
+++ b/public/css/style.css
@@ -157,3 +157,23 @@ div.feeds-holder {
 @media (max-width: 768px) {
   body.modal-open {
     position: fixed; } }
+
+.request-icon {
+  border-radius: 8px;
+  border: solid red 1px;
+  background-color: red;
+  height: 16px;
+  width: 16px;
+  overflow: visible;
+  position: absolute;
+  left: -15px;
+  top: 7px;
+}
+
+.request-icon-text {
+  color: white;
+  font-size: 0.8em;
+  position: relative;
+  left: 4px;
+  top: -4px;
+}

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -24,6 +24,7 @@
           {{/if}}
           {{# if_or logged_user.admin logged_user.approver }}
             <li class="hidden-xs"><a href="/requests/">Requests</a></li>
+            <li class="hidden-xs"><span class="request-icon"><span class="request-icon-text">{{requestCount}}</span></span></li>
           {{/if_or}}
 
           <li class="navbar-form navbar-left">
@@ -67,5 +68,3 @@
 </nav>
 
 </div>
-
-

--- a/views/requests.hbs
+++ b/views/requests.hbs
@@ -34,14 +34,10 @@
         {{#each to_be_approved_leaves }}
         <tr vpp="pending_for__{{this.user.email}}">
           <td>{{this.full_name}}</td>
-          <!-- <td>{{#with this.user}}{{this.full_name}}{{/with}}</td> -->
           <td>{{this.user.department.name}}</td>
-          <!-- <td>{{as_date this.createdAt}}</td> -->
           <td>{{this.created_at}}</td>
-          <!-- <td>From {{#with this.get_start_leave_day}}{{as_date this.date}}{{/with}} to {{#with this.get_end_leave_day}}{{as_date this.date}}{{/with}}</td> -->
           <td>From {{this.start_date}} to {{this.leave_date}}</td>
-          <!-- <td>{{#if this.is_pended_revoke_leave}}REVOKE {{/if}}{{this.leave_type.name}}</td> -->
-          <!-- <td>{{ this.get_deducted_days_number }}</td> -->
+          <td>{{#if this.leaveObject.is_pended_revoke_leave}}REVOKE {{/if}}{{this.leaveObject.leave_type.name}}</td>
           <td>
             <form action="/requests/reject/" method="POST">
             <input class="btn btn-warning" type="submit" value="Reject">

--- a/views/requests.hbs
+++ b/views/requests.hbs
@@ -35,9 +35,10 @@
         <tr vpp="pending_for__{{this.user.email}}">
           <td>{{this.full_name}}</td>
           <td>{{this.user.department.name}}</td>
-          <td>{{this.created_at}}</td>
+          <td>{{as_date this.created_at}}</td>
           <td>From {{this.start_date}} to {{this.leave_date}}</td>
           <td>{{#if this.leaveObject.is_pended_revoke_leave}}REVOKE {{/if}}{{this.leaveObject.leave_type.name}}</td>
+          <td>{{this.days}}</td>
           <td>
             <form action="/requests/reject/" method="POST">
             <input class="btn btn-warning" type="submit" value="Reject">

--- a/views/requests.hbs
+++ b/views/requests.hbs
@@ -33,12 +33,15 @@
       <tbody>
         {{#each to_be_approved_leaves }}
         <tr vpp="pending_for__{{this.user.email}}">
-          <td>{{#with this.user}}{{this.full_name}}{{/with}}</td>
+          <td>{{this.full_name}}</td>
+          <!-- <td>{{#with this.user}}{{this.full_name}}{{/with}}</td> -->
           <td>{{this.user.department.name}}</td>
-          <td>{{as_date this.createdAt}}</td>
-          <td>From {{#with this.get_start_leave_day}}{{as_date this.date}}{{/with}} to {{#with this.get_end_leave_day}}{{as_date this.date}}{{/with}}</td>
-          <td>{{#if this.is_pended_revoke_leave}}REVOKE {{/if}}{{this.leave_type.name}}</td>
-          <td>{{ this.get_deducted_days_number }}</td>
+          <!-- <td>{{as_date this.createdAt}}</td> -->
+          <td>{{this.created_at}}</td>
+          <!-- <td>From {{#with this.get_start_leave_day}}{{as_date this.date}}{{/with}} to {{#with this.get_end_leave_day}}{{as_date this.date}}{{/with}}</td> -->
+          <td>From {{this.start_date}} to {{this.leave_date}}</td>
+          <!-- <td>{{#if this.is_pended_revoke_leave}}REVOKE {{/if}}{{this.leave_type.name}}</td> -->
+          <!-- <td>{{ this.get_deducted_days_number }}</td> -->
           <td>
             <form action="/requests/reject/" method="POST">
             <input class="btn btn-warning" type="submit" value="Reject">


### PR DESCRIPTION
Completes entire Epic 1:

## Epic 1: New role: Approvers

This epics adds a new role: approver. Approvers can approve and reject requests, but don't have all of the admin access that an admin has.

- [X] As an Admin when I add a new user, I can choose to make them an approver<br>
- [X] As an Admin if I try to make someone an approver AND an admin I get an error: "User can only be approver or admin, not both"<br>
- [X] As an approver I can see a menu item in the top navbar next to calendar called "Requests" which links to "/requests"<br>
- [X] As an admin I can see the requests link as well<br>
- [X] As an employee I cannot see the requests link<br>
- [X] As an approver or admin, I can see a notification icon next to the request link that shows the number of pending requests<br>
- [X] As an approver, I can approve and reject requests<br>
- [X] As an approver, I do not have access to other admin functions (general, department, LDAP configuration, emails audit)<br>