### PR TITLE
Created backend role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swo
 node_modules/
 *.sqlite
+npm-debug.log

--- a/README.md
+++ b/README.md
@@ -55,11 +55,11 @@ This epics adds a new role: approver. Approvers can approve and reject requests,
 
 This epic adds a new role: backend user. Backend users can access general admin functions, but can't approve/reject requests.
 
-- [ ] As an Admin when I add a new user, I can choose to make them 'backend user'
-- [ ] As an Admin if I try to make someone a 'backend user' AND an admin I get an error: "User can only be approver or admin, not both"
-- [ ] As a Backend user, I can't see the 'Requests' menu item
-- [ ] As a Backend user, I have access to other admin functions (general, department, LDAP configuration, emails audit)
-- [ ] As a Backend user, when I browse '/request' I see only my personal requests, not the admin/approver view
+- [X] As an Admin when I add a new user, I can choose to make them 'backend user'
+- [X] As an Admin if I try to make someone a 'backend user' AND an admin I get an error: "User can only be approver or admin, not both"
+- [X] As a Backend user, I can't see the 'Requests' menu item
+- [X] As a Backend user, I have access to other admin functions (general, department, LDAP configuration, emails audit)
+- [X] As a Backend user, when I browse '/request' I see only my personal requests, not the admin/approver view
 
 # TimeOff.Management
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ This epics adds a new role: approver. Approvers can approve and reject requests,
 - [X] As an approver, I can approve and reject requests<br>
 - [X] As an approver, I do not have access to other admin functions (general, department, LDAP configuration, emails audit)<br>
 
+## STRETCH: Epic 2: New role: Backend User
+
+This epic adds a new role: backend user. Backend users can access general admin functions, but can't approve/reject requests.
+
+- [ ] As an Admin when I add a new user, I can choose to make them 'backend user'
+- [ ] As an Admin if I try to make someone a 'backend user' AND an admin I get an error: "User can only be approver or admin, not both"
+- [ ] As a Backend user, I can't see the 'Requests' menu item
+- [ ] As a Backend user, I have access to other admin functions (general, department, LDAP configuration, emails audit)
+- [ ] As a Backend user, when I browse '/request' I see only my personal requests, not the admin/approver view
 
 # TimeOff.Management
 

--- a/lib/model/db/user.js
+++ b/lib/model/db/user.js
@@ -60,6 +60,12 @@ module.exports = function(sequelize, DataTypes) {
           defaultValue : false,
           comment      : 'Indicate if account can approve or deny leave requests',
       },
+      backend : {
+          type         : DataTypes.BOOLEAN,
+          allowNull    : false,
+          defaultValue : false,
+          comment      : 'Indicate if account has admin functions except approve or deny leave requests',
+      },
       start_date : {
           type         : DataTypes.DATE,
           allowNull    : false,
@@ -120,7 +126,7 @@ function get_instance_methods(sequelize) {
     },
 
     is_admin : function() {
-        return this.admin === true;
+        return this.admin === true || this.backend === true;
     },
 
     full_name : function() {

--- a/lib/route/users.js
+++ b/lib/route/users.js
@@ -470,11 +470,12 @@ function get_and_validate_user_parameters(args) {
         password          = validator.trim(req.param('password_one')),
         password_confirm  = validator.trim(req.param('password_confirm')),
         admin             = validator.toBoolean(req.param('admin')),
-        approver             = validator.toBoolean(req.param('approver')),
+        approver          = validator.toBoolean(req.param('approver')),
+        backend           = validator.toBoolean(req.param('backend')),
         department_id;
 
     // Validate provided parameters
-    if (admin && approver) {
+    if (admin && approver || admin && backend || approver && backend) {
       throw new Error('User can only be approver or admin, not both.');
     }
 
@@ -575,6 +576,7 @@ function get_and_validate_user_parameters(args) {
         adjustment   : adjustment,
         admin        : admin,
         approver     : approver,
+        backend      : backend,
     };
 
     if ( password ) {

--- a/lib/view/helpers.js
+++ b/lib/view/helpers.js
@@ -90,6 +90,13 @@ module.exports = function(){
         return options.fn(this)
       }
       return null
+    },
+
+    if_func : function(callback, self, options) {
+      if( callback.call(self) ) {
+        return options.fn(this)
+      }
+      return null
     }
 
   };

--- a/views/partials/header.hbs
+++ b/views/partials/header.hbs
@@ -19,9 +19,9 @@
         {{# if logged_user }}
           <li><a href="/calendar/">Calendar</a></li>
           <li class="hidden-xs"><a href="/calendar/teamview/">Team View</a></li>
-          {{# if logged_user.admin }}
+          {{# if_func logged_user.is_admin logged_user }}
             <li class="hidden-xs"><a href="/users/">Employees</a></li>
-          {{/if}}
+          {{/if_func}}
           {{# if_or logged_user.admin logged_user.approver }}
             <li class="hidden-xs"><a href="/requests/">Requests</a></li>
             <li class="hidden-xs"><span class="request-icon"><span class="request-icon-text">{{requestCount}}</span></span></li>
@@ -37,7 +37,7 @@
       <ul class="nav navbar-nav navbar-right">
         <li>
           {{# if logged_user }}
-            {{# if logged_user.admin }}
+            {{# if_func logged_user.is_admin logged_user}}
             <li class="dropdown hidden-xs">
               <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-expanded="false"><span class="fa fa-gears"></span> <span class="caret"></span></a>
               <ul class="dropdown-menu" role="menu">
@@ -47,7 +47,7 @@
                 <li><a href="/audit/email/">Emails audit</a></li>
               </ul>
             </li>
-            {{/if}}
+            {{/if_func}}
             <li class="visible-xs-block"><a href="/requests/">My requests</a></li>
             <li class="visible-xs-block"><a href="/logout/">Logout</a></li>
             <li class="dropdown hidden-xs">

--- a/views/partials/user_requests.hbs
+++ b/views/partials/user_requests.hbs
@@ -1,6 +1,6 @@
 
 <div class="row main-row_header">
-  <p class="col-md-12">All absences</p>
+  <p class="col-md-12">My absences</p>
 </div>
 <div class="row">
   {{# unless leaves}}

--- a/views/requests.hbs
+++ b/views/requests.hbs
@@ -5,60 +5,62 @@
 
 {{> show_flash_messages }}
 
-<div class="row main-row_header">
-  <p class="col-md-12">Leave request to approve</p>
-</div>
+{{# if_or logged_user.admin logged_user.approver }}
+  <div class="row main-row_header">
+    <p class="col-md-12">Leave request to approve</p>
+  </div>
 
-<div class="row">
-  {{# unless to_be_approved_leaves}}
-  <div class="col-md-12 text-muted">
-    There are no leave request to decide on.
-  </div>
-  {{else}}
-  <div class="col-md-12">
-    <p class="visible-xs-block"><em class="text-muted">Scroll table horizontally</em></p>
-    <div class="table-responsive">
-    <table class="table table-hover">
-      <thead>
-        <tr>
-          <th>Employee</th>
-          <th>Department</th>
-          <th>Date of request</th>
-          <th>Leave dates</th>
-          <th>Type</th>
-          <th>Days</th>
-          <th colspan="2"></th>
-        </tr>
-      </thead>
-      <tbody>
-        {{#each to_be_approved_leaves }}
-        <tr vpp="pending_for__{{this.user.email}}">
-          <td>{{this.full_name}}</td>
-          <td>{{this.user.department.name}}</td>
-          <td>{{as_date this.created_at}}</td>
-          <td>From {{this.start_date}} to {{this.leave_date}}</td>
-          <td>{{#if this.leaveObject.is_pended_revoke_leave}}REVOKE {{/if}}{{this.leaveObject.leave_type.name}}</td>
-          <td>{{this.days}}</td>
-          <td>
-            <form action="/requests/reject/" method="POST">
-            <input class="btn btn-warning" type="submit" value="Reject">
-            <input type="hidden" value="{{this.id}}" name="request">
-            </form>
-          </td>
-          <td>
-            <form action="/requests/approve/" method="POST">
-            <input class="btn btn-success" type="submit" value="Approve">
-            <input type="hidden" value="{{this.id}}" name="request">
-            </form>
-          </td>
-        </tr>
-        {{/each}}
-      </tbody>
-    </table>
+  <div class="row">
+    {{# unless to_be_approved_leaves}}
+    <div class="col-md-12 text-muted">
+      There are no leave request to decide on.
     </div>
+    {{else}}
+    <div class="col-md-12">
+      <p class="visible-xs-block"><em class="text-muted">Scroll table horizontally</em></p>
+      <div class="table-responsive">
+      <table class="table table-hover">
+        <thead>
+          <tr>
+            <th>Employee</th>
+            <th>Department</th>
+            <th>Date of request</th>
+            <th>Leave dates</th>
+            <th>Type</th>
+            <th>Days</th>
+            <th colspan="2"></th>
+          </tr>
+        </thead>
+        <tbody>
+          {{#each to_be_approved_leaves }}
+          <tr vpp="pending_for__{{this.user.email}}">
+            <td>{{this.full_name}}</td>
+            <td>{{this.user.department.name}}</td>
+            <td>{{as_date this.created_at}}</td>
+            <td>From {{this.start_date}} to {{this.leave_date}}</td>
+            <td>{{#if this.leaveObject.is_pended_revoke_leave}}REVOKE {{/if}}{{this.leaveObject.leave_type.name}}</td>
+            <td>{{this.days}}</td>
+            <td>
+              <form action="/requests/reject/" method="POST">
+              <input class="btn btn-warning" type="submit" value="Reject">
+              <input type="hidden" value="{{this.id}}" name="request">
+              </form>
+            </td>
+            <td>
+              <form action="/requests/approve/" method="POST">
+              <input class="btn btn-success" type="submit" value="Approve">
+              <input type="hidden" value="{{this.id}}" name="request">
+              </form>
+            </td>
+          </tr>
+          {{/each}}
+        </tbody>
+      </table>
+      </div>
+    </div>
+    {{/unless}}
   </div>
-  {{/unless}}
-</div>
+{{/if_or}}
 
 {{> user_requests leaves=my_leaves }}
 

--- a/views/user_add.hbs
+++ b/views/user_add.hbs
@@ -62,6 +62,15 @@
   </div>
 
   <div class="form-group">
+    <div class="col-md-3 col-md-offset-3">
+      <label for="backend_inp" class="_col-md-2 control-label">
+        <input class="" id="backend_inp" name="backend" type="checkbox" />
+        Is backend user
+      </label>
+    </div>
+  </div>
+
+  <div class="form-group">
     <label for="start_date_inp" class="col-md-3 control-label">Started on</label>
     <div class="col-md-3 date">
       <input class="form-control" id="start_date_inp" type="text" name="start_date" required data-date-autoclose="1" data-provide="datepicker" data-date-format="{{#with logged_user.company }}{{this.get_default_date_format_for_date_picker}}{{/with}}" data-date-week-start="1" value="{{as_date booking_start}}" aria-describedby="start_date_help">

--- a/views/user_edit.hbs
+++ b/views/user_edit.hbs
@@ -71,6 +71,15 @@
   </div>
 
   <div class="form-group">
+    <div class="col-md-3 col-md-offset-3">
+      <label for="backend_inp" class="_col-md-2 control-label">
+        <input class="" id="backend_inp" name="backend" type="checkbox" {{# if employee.backend}} checked="checked"  {{/if}} >
+        Is backend user
+      </label>
+    </div>
+  </div>
+
+  <div class="form-group">
     <label for="start_date_inp" class="col-md-3 control-label">Started on</label>
     <div class="col-md-3 date">
       <input class="form-control" id="start_date_inp" type="text" name="start_date" required data-date-autoclose="1" data-provide="datepicker" data-date-format="{{#with logged_user.company }}{{this.get_default_date_format_for_date_picker}}{{/with}}" data-date-week-start="1" value="{{as_date employee.start_date}}" aria-describedby="start_date_help">

--- a/views/users.hbs
+++ b/views/users.hbs
@@ -40,6 +40,7 @@
             <th>Department</th>
             <th>Is Administrator?</th>
             <th>Is Approver?</th>
+            <th>Is Backend?</th>
             <th>Days used</th>
           </tr>
         </thead>
@@ -50,6 +51,7 @@
             <td class="user_department">{{this.department.name}}</td>
             <td>{{# if this.admin }}Yes{{else}}{{/if}}</td>
             <td>{{# if this.approver }}Yes{{else}}{{/if}}</td>
+            <td>{{# if this.backend }}Yes{{else}}{{/if}}</td>
             <td>{{this.calculate_number_of_days_taken_from_allowence}}</td>
           </tr>
           {{/each}}


### PR DESCRIPTION
Completed the following Epic:

STRETCH: Epic 2: New role: Backend User

This epic adds a new role: backend user. Backend users can access general admin functions, but can't approve/reject requests.

- [X] As an Admin when I add a new user, I can choose to make them 'backend user'
- [X] As an Admin if I try to make someone a 'backend user' AND an admin I get an error: "User can only be approver or admin, not both"
- [X] As a Backend user, I can't see the 'Requests' menu item
- [X] As a Backend user, I have access to other admin functions (general, department, LDAP configuration, emails audit)
- [X] As a Backend user, when I browse '/request' I see only my personal requests, not the admin/approver view
 